### PR TITLE
Added support for cross-origin images

### DIFF
--- a/src/browser-image.coffee
+++ b/src/browser-image.coffee
@@ -4,6 +4,7 @@ class BrowserImage extends Image
   constructor: (path, cb) ->
     @img = document.createElement('img')
     @img.src= path
+    @img.crossOrigin = 'anonymous'
 
     @img.onload = =>
       @_initCanvas()


### PR DESCRIPTION
Added support for cross-origin images. When drawing images to the canvas from a different domain, two things are necessary: first, the server must provide proper response headers for CORS-support e.g. Access-Control-Allow-Origin: *, and second for the image element to have the crossOrigin attribute set to 'anonymous'.

This small change to node-vibrant will allow for vibrant color extraction from images served from other domains (assuming the proper headers are provided by the server). Previous functionality should not be affected.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes