### PR TITLE
Add 'url' npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "jimp": "^0.2.4",
-    "quantize": "^1.0.1"
+    "quantize": "^1.0.1",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "bluebird": "^2.10.2",


### PR DESCRIPTION
'url' package was previously not declared as a dependency in package.json but was required in `image/browser.coffee` This change adds the url package as an npm dependency