### PR TITLE
Set crossOrigin on img before src is set.

### DIFF
--- a/src/image/browser.coffee
+++ b/src/image/browser.coffee
@@ -22,16 +22,16 @@ class BrowserImage extends Image
       path = @img.src
     else
       @img = document.createElement('img')
+      if not isRelativeUrl(path) && not isSameOrigin(window.location.href, path)
+        # must be set before src
+        @img.crossOrigin = 'anonymous'
       @img.src = path
-
-    if not isRelativeUrl(path) && not isSameOrigin(window.location.href, path)
-      @img.crossOrigin = 'anonymous'
 
     @img.onload = =>
       @_initCanvas()
       cb?(null, @)
 
-    # Alreayd loaded
+    # Already loaded
     if @img.complete
       @img.onload()
 

--- a/test/vibrant.browser-spec.coffee
+++ b/test/vibrant.browser-spec.coffee
@@ -85,14 +85,16 @@ describe "Vibrant", ->
   describe "Browser Image", ->
     loc = window.location
     BrowserImage = Vibrant.DefaultOpts.Image
-    CROS_URL = "http://example.com/foo.jpg"
+    CORS_URL = "https://httpbin.org/image/png"
     RELATIVE_URL = "foo/bar.jpg"
     SAME_ORIGIN_URL = "#{loc.protocol}//#{loc.host}/foo/bar.jpg"
-    it "should set crossOrigin flag for images form foreign origin", ->
-      m = new BrowserImage(CROS_URL)
-      expect(m.img.crossOrigin, "#{CROS_URL} should have crossOrigin === 'anonymous'")
-        .to.equal("anonymous")
-
+    it "should set crossOrigin flag for images form foreign origin", (done) ->
+      m = new BrowserImage CORS_URL, (err) =>
+        if err then throw err
+        expect(m.img.crossOrigin, "#{CORS_URL} should have crossOrigin === 'anonymous'")
+          .to.equal("anonymous")
+        expect(m.getImageData()).to.be.an.instanceof(ImageData)
+        done()
 
     it "should not set crossOrigin flag for images from same origin", ->
       m1 = new BrowserImage(RELATIVE_URL)


### PR DESCRIPTION
> You must set the CORS request before the src
https://stackoverflow.com/a/23123261

because as soon as you set the src attribute it sends the request, and crossOrigin will have no effect.