### PR TITLE
Avoid calling `count` of undefined

### DIFF
--- a/src/quantizer/impl/mmcq.coffee
+++ b/src/quantizer/impl/mmcq.coffee
@@ -66,7 +66,7 @@ class MMCQ
     while iteration < maxIterations
       iteration++
       vbox = pq.pop()
-      if !vbox.count()
+      if !vbox || !vbox.count()
         continue
 
       [vbox1, vbox2] = vbox.split()


### PR DESCRIPTION
Should address this:

 error  in ./assets/img/press/logo-white.png
Module build failed: TypeError: Cannot read property 'count' of undefined
    at _splitBoxes (/Users/.../node_modules/node-vibrant/src/quantizer/mmcq.ts:20:18)
    at MMCQ (/Users/.../node_modules/node-vibrant/src/quantizer/mmcq.ts:58:5)
    at Vibrant._process (/Users/.../node_modules/node-vibrant/src/vibrant.ts:55:33)
    at /Users/.../node_modules/node-vibrant/src/vibrant.ts:71:35
    at tryCatcher (/Users/.../node_modules/bluebird/js/release/util.js:16:23)
...