### PR TITLE
Allow loading images with crossorigin="use-credentials"

### DIFF
--- a/src/image/browser.ts
+++ b/src/image/browser.ts
@@ -102,6 +102,8 @@ export default class BroswerImage extends ImageBase {
         return this._context.getImageData(0, 0, this._width, this._height)
     }
     remove(): void {
-        this._canvas.parentNode.removeChild(this._canvas)
+        if (this._canvas && this._canvas.parentNode) {
+            this._canvas.parentNode.removeChild(this._canvas)
+        }
     }
 }

--- a/src/image/browser.ts
+++ b/src/image/browser.ts
@@ -20,7 +20,7 @@ function isSameOrigin(a: string, b: string): boolean {
         && ua.port === ub.port
 }
 
-export default class BroswerImage extends ImageBase {
+export default class BrowserImage extends ImageBase {
     image: HTMLImageElement
     private _canvas: HTMLCanvasElement
     private _context: CanvasRenderingContext2D

--- a/src/image/browser.ts
+++ b/src/image/browser.ts
@@ -46,7 +46,11 @@ export default class BroswerImage extends ImageBase {
         let src: string = null
         if (typeof image === 'string') {
             img = document.createElement('img')
-            src = image
+            src = img.src = image
+
+            if (!isRelativeUrl(src) && !isSameOrigin(window.location.href, src)) {
+                img.crossOrigin = 'anonymous'
+            }    
         } else if (image instanceof HTMLImageElement) {
             img = image
             src = image.src
@@ -54,14 +58,6 @@ export default class BroswerImage extends ImageBase {
             return Bluebird.reject(new Error(`Cannot load buffer as an image in browser`))
         }
         this.image = img
-
-        if (!isRelativeUrl(src) && !isSameOrigin(window.location.href, src)) {
-            img.crossOrigin = 'anonymous'
-        }
-
-        if (typeof image === 'string') {
-            img.src = src
-        }
 
         return new Bluebird<ImageBase>((resolve, reject) => {
             let onImageLoad = () => {


### PR DESCRIPTION
Currently there aren't any ways to customize how images are loaded via CORS aside from making a new image class. I've adjusted `BrowserImage` to keep whatever CORS mode is already on the passed in `HTMLImageElement`, so to load an image with "use-credentials", I can do

```javascript
const img = document.createElement('img')
img.crossOrigin = 'use-credentials'
img.src = 'https://mydomain.com/a.png'
return Vibrant.from(img).getPalette()
```

In the future I think there should be a better way to customize this behavior, but this suits my needs for now.