### PR TITLE
Replaced Bluebird with native Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Extract prominent colors from an image.
 
 ## New WebWorker support in v3.0
 
-Quantization is the most time-consuming stage in `node-vibrant`. In v3.0, the quantization can be run in the WebWorker to avoid freezing the UI thread. 
+Quantization is the most time-consuming stage in `node-vibrant`. In v3.0, the quantization can be run in the WebWorker to avoid freezing the UI thread.
 
 Here's how to use this feature:
 1. Use WebWorker build `dist/vibrant.worker.js` or `dist/vibrant.worker.min.js`. Or if you are re-bundling with webpack, use `lib/bundle.worker.js` as entry
@@ -98,8 +98,8 @@ Name    |  Description
 ##### `ImageSource`
 
 ```ts
-export type ImageSource = string 
-  | HTMLImageElement  // Browser only 
+export type ImageSource = string
+  | HTMLImageElement  // Browser only
   | Buffer            // Node.js only
 ```
 
@@ -130,7 +130,7 @@ Field          | Default                         | Description
 ##### `Resolvable<T>`
 
 ```ts
-export type Resolvable<T> = T | Bluebird<T>
+export type Resolvable<T> = T | Promise<T>
 ```
 
 ##### `Quantizer`
@@ -160,7 +160,7 @@ export interface Filter {
 }
 ```
 
-#### `getPalette(cb?: Callback<Palette>): Bluebird<Palette>`
+#### `getPalette(cb?: Callback<Palette>): Promise<Palette>`
 
 Name | Description
 ---- | -----------------
@@ -174,7 +174,7 @@ export interface Callback<T> {
 }
 ```
 
-#### `getSwatches(cb?: Callback<Palette>): Bluebird<Palette>`
+#### `getSwatches(cb?: Callback<Palette>): Promise<Palette>`
 Alias of `getPalette`.
 
 ### `Vibrant.Builder`
@@ -222,10 +222,10 @@ Sets `opts.generator` to `generator`. Returns this `Builder` instance.
 #### `build(): Vibrant`
 Builds and returns a `Vibrant` instance as configured.
 
-#### `getPalette(cb?: Callback<Palette>): Bluebird<Palette>`
+#### `getPalette(cb?: Callback<Palette>): Promise<Palette>`
 Builds a `Vibrant` instance as configured and calls its `getPalette` method.
 
-#### `getSwatches(cb? Callback<Palette>): Bluebird<Palette>`
+#### `getSwatches(cb? Callback<Palette>): Promise<Palette>`
 Alias of `getPalette`.
 
 ### `Vibrant.Swatch`

--- a/package.json
+++ b/package.json
@@ -9,11 +9,8 @@
     "example": "examples"
   },
   "dependencies": {
-    "@types/bluebird": "^3.0.37",
-    "@types/jimp": "^0.2.0",
     "@types/lodash": "^4.14.53",
     "@types/node": "^8.0.53",
-    "bluebird": "^3.4.7",
     "jimp": "^0.2.27",
     "lodash": "^4.17.4",
     "url": "^0.11.0"

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,4 +1,3 @@
-import Bluebird = require('bluebird')
 import clone = require('lodash/clone')
 
 import {
@@ -73,10 +72,10 @@ export default class Builder {
         return new Vibrant(this._src, this._opts)
     }
 
-    getPalette(cb?: Callback<Palette>): Bluebird<Palette> {
+    getPalette(cb?: Callback<Palette>): Promise<Palette> {
         return this.build().getPalette(cb)
     }
-    getSwatches(cb?: Callback<Palette>): Bluebird<Palette> {
+    getSwatches(cb?: Callback<Palette>): Promise<Palette> {
         return this.build().getPalette(cb)
     }
 }

--- a/src/image/base.ts
+++ b/src/image/base.ts
@@ -1,8 +1,7 @@
-import * as Bluebird from 'bluebird'
 import { Filter, Image, Options, ImageData, ImageSource } from '../typing'
 
 export abstract class ImageBase implements Image {
-    abstract load(image: ImageSource): Bluebird<ImageBase>
+    abstract load(image: ImageSource): Promise<ImageBase>
     abstract clear(): void
     abstract update(imageData: ImageData): void
     abstract getWidth(): number
@@ -28,7 +27,7 @@ export abstract class ImageBase implements Image {
         if (ratio < 1) this.resize(width * ratio, height * ratio, ratio)
     }
 
-    applyFilter(filter: Filter): Bluebird<ImageData> {
+    applyFilter(filter: Filter): Promise<ImageData> {
         let imageData = this.getImageData()
 
         if (typeof filter === 'function') {
@@ -46,7 +45,6 @@ export abstract class ImageBase implements Image {
             }
         }
 
-
-        return Bluebird.resolve(imageData)
+        return Promise.resolve(imageData)
     }
-} 
+}

--- a/src/image/browser.ts
+++ b/src/image/browser.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird'
 import { Options, ImageData, ImageSource, ImageCallback } from '../typing'
 import { ImageBase } from './base'
 import * as Url from 'url'
@@ -32,7 +31,7 @@ export default class BroswerImage extends ImageBase {
         let context = this._context = canvas.getContext('2d')
 
         canvas.className = 'vibrant-canvas'
-        canvas.style.display = 'none' 
+        canvas.style.display = 'none'
 
         this._width = canvas.width = img.width
         this._height = canvas.height = img.height
@@ -41,7 +40,7 @@ export default class BroswerImage extends ImageBase {
 
         document.body.appendChild(canvas)
     }
-    load(image: ImageSource): Bluebird<ImageBase> {
+    load(image: ImageSource): Promise<ImageBase> {
         let img: HTMLImageElement = null
         let src: string = null
         if (typeof image === 'string') {
@@ -51,7 +50,7 @@ export default class BroswerImage extends ImageBase {
             img = image
             src = image.src
         } else {
-            return Bluebird.reject(new Error(`Cannot load buffer as an image in browser`))
+            return Promise.reject(new Error(`Cannot load buffer as an image in browser`))
         }
         this.image = img
 
@@ -63,7 +62,7 @@ export default class BroswerImage extends ImageBase {
             img.src = src
         }
 
-        return new Bluebird<ImageBase>((resolve, reject) => {
+        return new Promise<ImageBase>((resolve, reject) => {
             let onImageLoad = () => {
                 this._initCanvas()
                 resolve(this)

--- a/src/image/node.ts
+++ b/src/image/node.ts
@@ -50,13 +50,11 @@ export default class NodeImage extends ImageBase {
     private _loadByJimp(src: NodeImageSource): Promise<ImageBase> {
         // NOTE: TypeScript doesn't support union type to overloads yet
         //       Use type assertion to bypass compiler error
-        return new Promise<ImageBase>((resolve, reject) => {
-            Jimp.read(src, (err, result) => {
-                if (err) return reject(err)
+        return Jimp.read(src)
+            .then((result) => {
                 this._image = result
-                resolve(this)
+                return this
             })
-        })
     }
     load(image: ImageSource): Promise<ImageBase> {
         if (typeof image === 'string') {

--- a/src/quantizer/worker.ts
+++ b/src/quantizer/worker.ts
@@ -1,6 +1,5 @@
 import WorkerPool from './worker/pool'
 
-import Bluebird = require('bluebird')
 import {
     Quantizer,
     Pixels,
@@ -8,7 +7,7 @@ import {
 } from '../typing'
 import { Swatch } from '../color'
 
-const quantizeInWorker: Quantizer = (pixels: Pixels, opts: ComputedOptions): Bluebird<Swatch[]> =>
+const quantizeInWorker: Quantizer = (pixels: Pixels, opts: ComputedOptions): Promise<Swatch[]> =>
     WorkerPool.instance.quantize(pixels, opts)
 
 export default quantizeInWorker

--- a/src/quantizer/worker/pool.ts
+++ b/src/quantizer/worker/pool.ts
@@ -1,4 +1,3 @@
-import Bluebird = require('bluebird')
 import { Swatch } from '../../color'
 import omit = require('lodash/omit')
 import find = require('lodash/find')
@@ -9,7 +8,7 @@ import {
     ComputedOptions
 } from '../../typing'
 import {
-    DeferredBluebird,
+    DeferredPromise,
     defer
 } from '../../util'
 
@@ -20,7 +19,7 @@ import {
 } from './common'
 
 interface Task extends WorkerRequest{
-    deferred: DeferredBluebird<Swatch[]>
+    deferred: DeferredPromise<Swatch[]>
 }
 
 interface TaskWorker extends Worker {
@@ -63,7 +62,7 @@ export default class WorkerPool {
         return worker
     }
 
-    private _enqueue(pixels: Pixels, opts: ComputedOptions): Bluebird<Swatch[]> {
+    private _enqueue(pixels: Pixels, opts: ComputedOptions): Promise<Swatch[]> {
         let d = defer<Swatch[]>()
 
         // make task item
@@ -133,7 +132,7 @@ export default class WorkerPool {
         // Try dequeue next task
         this._tryDequeue()
     }
-    quantize(pixels: Pixels, opts: ComputedOptions): Bluebird<Swatch[]> {
+    quantize(pixels: Pixels, opts: ComputedOptions): Promise<Swatch[]> {
         return this._enqueue(pixels, opts)
     }
 }

--- a/src/test/common/helper.ts
+++ b/src/test/common/helper.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai'
 import { VibrantStatic } from '../../typing'
 import Builder from '../../builder'
 import path = require('path')
-import Promise = require('bluebird')
 import { Palette, Swatch } from '../../color'
 import util = require('../../util')
 import _ = require('lodash')
@@ -108,4 +107,3 @@ export const testVibrantAsPromised = (Vibrant: VibrantStatic, sample: Sample, pa
         .then(palette => cb(null, palette))
         .catch(e => cb(e))
 }
-

--- a/src/test/common/helper.ts
+++ b/src/test/common/helper.ts
@@ -80,10 +80,12 @@ const paletteCallback = (references: any, sample: Sample, done?: MochaDone) =>
 
         displayColorDiffTable(sample.filePath, diffTable)
 
-        expect(failCount, `${failCount} colors are too diffrent from reference palettes`)
-            .to.equal(0)
+        setTimeout(() => {
+            expect(failCount, `${failCount} colors are too diffrent from reference palettes`)
+                .to.equal(0)
 
-        if (typeof done === 'function') done()
+            if (typeof done === 'function') done()
+        })
     }
 
 export const testVibrant = (Vibrant: VibrantStatic, sample: Sample, done: MochaDone, pathKey: SamplePathKey = 'filePath', builderCallback: (b: Builder) => Builder = null, references: any = REFERENCE_PALETTE_WITH_FILTER) => {

--- a/src/test/common/server.ts
+++ b/src/test/common/server.ts
@@ -1,6 +1,5 @@
 import path = require('path')
 import http = require('http')
-import util = require('util')
 import finalhandler = require('finalhandler')
 import serveStatic = require('serve-static')
 
@@ -10,10 +9,4 @@ const serverHandler = (req: http.ServerRequest, res: http.ServerResponse) => {
     return staticFiles(<any>req, <any>res, done)
 }
 
-export const createSampleServer = () => {
-    let server = http.createServer(serverHandler) as any
-
-    server.listen = util.promisify(server.listen)
-    server.close = util.promisify(server.close)
-    return server as http.Server;
-}
+export const createSampleServer = () => http.createServer(serverHandler)

--- a/src/test/common/server.ts
+++ b/src/test/common/server.ts
@@ -1,6 +1,6 @@
-import Promise = require('bluebird')
 import path = require('path')
 import http = require('http')
+import util = require('util')
 import finalhandler = require('finalhandler')
 import serveStatic = require('serve-static')
 
@@ -11,10 +11,9 @@ const serverHandler = (req: http.ServerRequest, res: http.ServerResponse) => {
 }
 
 export const createSampleServer = () => {
-    let server = http.createServer(serverHandler)
+    let server = http.createServer(serverHandler) as any
 
-    Promise.promisify(server.listen)
-    Promise.promisify(server.close)
-    return server
+    server.listen = util.promisify(server.listen)
+    server.close = util.promisify(server.close)
+    return server as http.Server;
 }
-

--- a/src/test/vibrant.browser-spec.ts
+++ b/src/test/vibrant.browser-spec.ts
@@ -19,7 +19,7 @@ import {
 
 describe('Vibrant', () => {
   it('Async import', () =>
-    System.import('../browser').then((v: any) => {
+    import('../browser').then((v: any) => {
       expect(v, 'Vibrant').not.to.be.undefined
       expect(v.Util, 'Vibrant.Util').not.to.be.undefined
       expect(v.Quantizer, 'Vibrant.Quantizer').not.to.be.undefined

--- a/src/test/vibrant.spec.ts
+++ b/src/test/vibrant.spec.ts
@@ -30,7 +30,7 @@ describe('Palette Extraction', () => {
     describe('process samples (no filters)', () =>
         SAMPLES.forEach((sample) => {
             const builderCallback = (builder: Builder) => builder.clearFilters()
-            
+
             it(`${sample.fileName} (callback)`, done => testVibrant(Vibrant, sample, done, 'filePath', builderCallback, REFERENCE_PALETTE))
             it(`${sample.fileName} (Promise)`, () => testVibrantAsPromised(Vibrant, sample, 'filePath', builderCallback, REFERENCE_PALETTE))
         })
@@ -41,12 +41,12 @@ describe('Palette Extraction', () => {
     describe('process remote images (http)', function () {
         let server: http.Server = null
 
-        before(() => {
+        before((done) => {
             server = createSampleServer()
-            return server.listen(TEST_PORT)
+            return server.listen(TEST_PORT, done)
         })
 
-        after(() => server.close())
+        after((done) => server.close(done))
 
         SAMPLES.forEach((sample) => {
             it(`${sample.url} (callback)`, done => testVibrant(Vibrant, sample, done))

--- a/src/typing.ts
+++ b/src/typing.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird'
 import { Palette, Swatch } from './color'
 import Builder from './builder'
 
@@ -22,7 +21,7 @@ export interface ImageData {
 }
 
 export interface Image {
-    load(image: ImageSource): Bluebird<Image>
+    load(image: ImageSource): Promise<Image>
     clear(): void
     update(imageData: ImageData): void
     getWidth(): number
@@ -30,12 +29,12 @@ export interface Image {
     resize(targetWidth: number, targetHeight: number, ratio: number): void
     getPixelCount(): number
     getImageData(): ImageData
-    applyFilter(filter: Filter): Bluebird<ImageData>
+    applyFilter(filter: Filter): Promise<ImageData>
     remove(): void
     scaleDown(opts: Options): void
 }
 
-export type Resolvable<T> = T | Bluebird<T>
+export type Resolvable<T> = T | Promise<T>
 
 export interface ImageClass {
     new (): Image

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird'
 import { Vec3 } from './color'
 
 export const DELTAE94_DIFF_STATUS = {
@@ -16,16 +15,16 @@ export interface IndexedObject {
     [key: string]: any
 }
 
-export interface DeferredBluebird<R> {
-    resolve: (thenableOrResult: R | Bluebird.Thenable<R>) => void
+export interface DeferredPromise<R> {
+    resolve: (thenableOrResult: R | PromiseLike<R>) => void
     reject: (error: any) => void
-    promise: Bluebird<R>
+    promise: Promise<R>
 }
 
-export function defer<R>(): DeferredBluebird<R> {
-    let resolve: (thenableOrResult: R | Bluebird.Thenable<R>) => void
+export function defer<R>(): DeferredPromise<R> {
+    let resolve: (thenableOrResult: R | PromiseLike<R>) => void
     let reject: (error: any) => void
-    let promise = new Bluebird<R>((_resolve, _reject) => {
+    let promise = new Promise<R>((_resolve, _reject) => {
         resolve = _resolve
         reject = _reject
     })

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,12 @@
         "module": "commonjs",
         "target": "es5",
         "noImplicitAny": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "lib": [
+            "dom",
+            "es5",
+            "es2015.promise"
+        ]
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
Only 1 function uses Bluebird-specific functions, so this is a simple change. Removing Bluebird saves 81 KB in the minified file, or 60%! 

Additionally removed @types/jimp since it just contains stub typings.

If you need to keep supporting environments without promises, a different promise polyfill could be used instead. For example, [es6-promise](https://github.com/stefanpenner/es6-promise) is only 2 KB.