### PR TITLE
Fill more empty swatches (update and expansion on #51)

### DIFF
--- a/src/generator/default.ts
+++ b/src/generator/default.ts
@@ -200,6 +200,31 @@ function _generateEmptySwatches(palette: Palette, maxPopulation: number, opts: D
         l = opts.targetDarkLuma
         palette.DarkVibrant = new Swatch(hslToRgb(h, s, l), 0)
     }
+    if (palette.LightVibrant === null && palette.Vibrant !== null) {
+      let [h, s, l] = palette.Vibrant.getHsl()
+      l = opts.targetLightLuma
+      palette.LightVibrant = new Swatch(hslToRgb(h, s, l), 0)
+    }
+    if (palette.LightVibrant === null && palette.Vibrant !== null) {
+      let [h, s, l] = palette.Vibrant.getHsl()
+      l = opts.targetLightLuma
+      palette.LightVibrant = new Swatch(hslToRgb(h, s, l), 0)
+    }
+    if (palette.Muted === null && palette.Vibrant !== null) {
+      let [h, s, l] = palette.Vibrant.getHsl()
+      l = opts.targetMutesSaturation
+      palette.LightVibrant = new Swatch(hslToRgb(h, s, l), 0)
+    }
+    if (palette.DarkMuted === null && palette.DarkVibrant !== null) {
+      let [h, s, l] = palette.DarkVibrant.getHsl()
+      l = opts.targetMutesSaturation
+      palette.DarkMuted = new Swatch(hslToRgb(h, s, l), 0)
+    }
+    if (palette.LightMuted === null && palette.LightVibrant !== null) {
+      let [h, s, l] = palette.LightVibrant.getHsl()
+      l = opts.targetMutesSaturation
+      palette.DarkMuted = new Swatch(hslToRgb(h, s, l), 0)
+    }
 }
 
 const DefaultGenerator: Generator = (swatches: Array<Swatch>, opts?: DefaultGeneratorOptions): Palette => {

--- a/src/generator/default.ts
+++ b/src/generator/default.ts
@@ -194,6 +194,10 @@ function _generateEmptySwatches(palette: Palette, maxPopulation: number, opts: D
         let [h, s, l] = palette.DarkVibrant.getHsl()
         l = opts.targetNormalLuma
         palette.Vibrant = new Swatch(hslToRgb(h, s, l), 0)
+    } else if (palette.Vibrant === null && palette.LightVibrant !== null) {
+        let [h, s, l] = palette.LightVibrant.getHsl()
+        l = opts.targetNormalLuma
+        palette.Vibrant = new Swatch(hslToRgb(h, s, l), 0)
     }
     if (palette.DarkVibrant === null && palette.Vibrant !== null) {
         let [h, s, l] = palette.Vibrant.getHsl()
@@ -205,15 +209,10 @@ function _generateEmptySwatches(palette: Palette, maxPopulation: number, opts: D
       l = opts.targetLightLuma
       palette.LightVibrant = new Swatch(hslToRgb(h, s, l), 0)
     }
-    if (palette.LightVibrant === null && palette.Vibrant !== null) {
-      let [h, s, l] = palette.Vibrant.getHsl()
-      l = opts.targetLightLuma
-      palette.LightVibrant = new Swatch(hslToRgb(h, s, l), 0)
-    }
     if (palette.Muted === null && palette.Vibrant !== null) {
       let [h, s, l] = palette.Vibrant.getHsl()
       l = opts.targetMutesSaturation
-      palette.LightVibrant = new Swatch(hslToRgb(h, s, l), 0)
+      palette.Muted = new Swatch(hslToRgb(h, s, l), 0)
     }
     if (palette.DarkMuted === null && palette.DarkVibrant !== null) {
       let [h, s, l] = palette.DarkVibrant.getHsl()
@@ -223,7 +222,7 @@ function _generateEmptySwatches(palette: Palette, maxPopulation: number, opts: D
     if (palette.LightMuted === null && palette.LightVibrant !== null) {
       let [h, s, l] = palette.LightVibrant.getHsl()
       l = opts.targetMutesSaturation
-      palette.DarkMuted = new Swatch(hslToRgb(h, s, l), 0)
+      palette.LightMuted = new Swatch(hslToRgb(h, s, l), 0)
     }
 }
 

--- a/src/generator/default.ts
+++ b/src/generator/default.ts
@@ -190,6 +190,18 @@ function _generateVariationColors(swatches: Array<Swatch>, maxPopulation: number
 }
 
 function _generateEmptySwatches(palette: Palette, maxPopulation: number, opts: DefaultGeneratorOptions): void {
+    if (palette.Vibrant === null && palette.DarkVibrant === null && palette.LightVibrant === null) {
+        if (palette.DarkVibrant === null && palette.DarkMuted !== null) {
+            let [h, s, l] = palette.DarkMuted.getHsl()
+            l = opts.targetDarkLuma
+            palette.DarkVibrant = new Swatch(hslToRgb(h, s, l), 0)
+        }
+        if (palette.LightVibrant === null && palette.LightMuted !== null) {
+            let [h, s, l] = palette.LightMuted.getHsl()
+            l = opts.targetDarkLuma
+            palette.DarkVibrant = new Swatch(hslToRgb(h, s, l), 0)
+        }
+    }
     if (palette.Vibrant === null && palette.DarkVibrant !== null) {
         let [h, s, l] = palette.DarkVibrant.getHsl()
         l = opts.targetNormalLuma


### PR DESCRIPTION
Muted variations were not being filled if empty, this adds them so they're available from Vibrant. Also, try filling Vibrant from LightVibrant (if available).
This fixes ismamz/postcss-get-color#3

As mentioned previously in #51.

This PR was made because there were some non-trivial merge requests (and issues with the previous merge request branch, given that there was a `git push -f` at some point on master since). I've done my best to preserve original credit in the commit author field, even as I had to rewrite the CoffeeScript to TypeScript :) 