### PR TITLE
add tslint linting file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/serve-static": "^1.7.31",
     "@types/table": "^4.0.1",
     "chai": "^4.1.2",
+    "eslint-plugin-typescript": "^0.14.0",
     "finalhandler": "^1.0.0",
     "karma": "^1.5.0",
     "karma-chai": "^0.1.0",
@@ -36,9 +37,11 @@
     "mocha": "^4.0.1",
     "rimraf": "^2.6.1",
     "serve-static": "^1.11.2",
+    "standard": "^12.0.1",
     "table": "^4.0.1",
     "ts-loader": "^3.1.1",
     "typescript": "^2.6.1",
+    "typescript-eslint-parser": "^21.0.2",
     "webpack": "^3.8.1",
     "worker-loader": "^1.1.0"
   },
@@ -71,5 +74,9 @@
     "colour"
   ],
   "author": "akfish",
-  "license": "MIT"
+  "license": "MIT",
+  "standard": {
+    "parser": "typescript-eslint-parser",
+    "plugins": [ "typescript" ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@types/serve-static": "^1.7.31",
     "@types/table": "^4.0.1",
     "chai": "^4.1.2",
-    "eslint-plugin-typescript": "^0.14.0",
     "finalhandler": "^1.0.0",
     "karma": "^1.5.0",
     "karma-chai": "^0.1.0",
@@ -37,11 +36,9 @@
     "mocha": "^4.0.1",
     "rimraf": "^2.6.1",
     "serve-static": "^1.11.2",
-    "standard": "^12.0.1",
     "table": "^4.0.1",
     "ts-loader": "^3.1.1",
     "typescript": "^2.6.1",
-    "typescript-eslint-parser": "^21.0.2",
     "webpack": "^3.8.1",
     "worker-loader": "^1.1.0"
   },
@@ -74,9 +71,5 @@
     "colour"
   ],
   "author": "akfish",
-  "license": "MIT",
-  "standard": {
-    "parser": "typescript-eslint-parser",
-    "plugins": [ "typescript" ]
-  }
+  "license": "MIT"
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,32 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {
+        "indent": [true, "spaces", 4],
+        "arrow-parens": true,
+        "semicolon": [true, "never"],
+        "curly": [true, "ignore-same-line"],
+        "member-access": false,
+        "quotemark": [true, "single"],
+        "prefer-const": false,
+        "no-bitwise": false,
+        "variable-name": false,
+        "ordered-imports": false,
+        "object-literal-sort-keys": false,
+        "align": false,
+        "member-ordering": false,
+        "interface-name": false,
+        "trailing-comma": false,
+        "no-var-requires": false,
+        "no-unused-expression": false,
+        "array-type": false,
+        "no-empty": false,
+        "ban-types": false,
+        "one-variable-per-declaration": false,
+        "prefer-for-of": false
+    },
+    "rulesDirectory": []
+}


### PR DESCRIPTION
After initially looking into using standard for linting, I noticed that the current code standard of the project does not align as closely to it as I initially thought. I then made a custom tslint file to match the codebase as closely as possible. After this is merged, a simple `npx tslint src/**/*.ts --fix` will bring most of the codebase to a similar code style as defined by the linting file