### PR TITLE
Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,8 @@
     "example": "examples"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.53",
     "@types/node": "^10.11.7",
     "jimp": "^0.5.4",
-    "lodash": "^4.17.4",
     "url": "^0.11.0"
   },
   "devDependencies": {

--- a/src/browser.worker.ts
+++ b/src/browser.worker.ts
@@ -1,8 +1,7 @@
-/* global Window */
 import WebWorker from './quantizer/worker'
 import Vibrant = require('./browser')
 
 // TODO: use this as webpack entry instead. Let webpack generate UMD module wrapper.
 Vibrant.Quantizer.WebWorker = WebWorker
 
-export = Vibrant
+export default Vibrant

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -11,15 +11,13 @@ import {
 import { Palette } from './color'
 import Vibrant from './vibrant'
 
-import clone = require('lodash/clone')
-
 export default class Builder {
   private _src: ImageSource
   private _opts: Partial<Options>
-  constructor(src: ImageSource, opts: Partial<Options> = {}) {
+  constructor (src: ImageSource, opts: Partial<Options> = {}) {
     this._src = src
     this._opts = opts
-    this._opts.filters = clone(Vibrant.DefaultOpts.filters)
+    this._opts.filters = Vibrant.DefaultOpts.filters.slice(0)
   }
 
   maxColorCount(n: number): Builder {

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,6 +1,5 @@
 import { Filter } from './typing'
 import { rgbToHsl, rgbToHex } from './util'
-import filter = require('lodash/filter')
 
 export type Vec3 = [number, number, number] 
 
@@ -15,9 +14,9 @@ export interface Palette {
 }
 
 export class Swatch {
-  static applyFilter(colors: Swatch[], f: Filter): Swatch[] {
+  static applyFilter (colors: Swatch[], f: Filter): Swatch[] {
     return typeof f === 'function'
-      ? filter(colors, ({ r, g, b }) => f(r, g, b, 255))
+      ? colors.filter(({ r, g, b }) => f(r, g, b, 255))
       : colors
   }
   private _hsl: Vec3

--- a/src/filter/default.ts
+++ b/src/filter/default.ts
@@ -1,4 +1,3 @@
-import { Filter } from '../typing'
 export default function defaultFilter (r: number, g: number, b: number, a: number): boolean {
   return a >= 125 &&
     !(r > 250 && g > 250 && b > 250)

--- a/src/filter/index.ts
+++ b/src/filter/index.ts
@@ -1,4 +1,4 @@
-import { Filter, ImageData, Options } from '../typing'
+import { Filter } from '../typing'
 export { default as Default } from './default'
 
 export function combineFilters (filters: Filter[]): Filter {

--- a/src/generator/default.ts
+++ b/src/generator/default.ts
@@ -1,7 +1,6 @@
 import { Swatch, Palette } from '../color'
 import { Generator } from '../typing'
 import { hslToRgb } from '../util'
-import defaults = require('lodash/defaults')
 
 interface DefaultGeneratorOptions {
   targetDarkLuma: number,
@@ -235,7 +234,7 @@ function _generateEmptySwatches (palette: Palette, maxPopulation: number, opts: 
 }
 
 const DefaultGenerator: Generator = (swatches: Array<Swatch>, opts?: DefaultGeneratorOptions): Palette => {
-  opts = <DefaultGeneratorOptions>defaults({}, opts, DefaultOpts)
+  opts = Object.assign({}, DefaultOpts, opts)
   let maxPopulation = _findMaxPopulation(swatches)
 
   let palette = _generateVariationColors(swatches, maxPopulation, opts)

--- a/src/image/browser.ts
+++ b/src/image/browser.ts
@@ -1,18 +1,17 @@
 /* eslint-env browser */
-import { Options, ImageData, ImageSource, ImageCallback } from '../typing'
+import { ImageData as NodeImageData, ImageSource } from '../typing'
 import { ImageBase } from './base'
-import * as Url from 'url'
 
 function isRelativeUrl (url: string): boolean {
-  let u = Url.parse(url)
-  return u.protocol === null &&
-    u.host === null &&
-    u.port === null
+  let u = new URL(url, location.href)
+  return u.protocol === location.protocol &&
+    u.host === location.host &&
+    u.port === location.port
 }
 
 function isSameOrigin (a: string, b: string): boolean {
-  let ua = Url.parse(a)
-  let ub = Url.parse(b)
+  let ua = new URL(a)
+  let ub = new URL(b)
 
   // https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
   return ua.protocol === ub.protocol &&
@@ -70,14 +69,14 @@ export default class BrowserImage extends ImageBase {
         onImageLoad()
       } else {
         img.onload = onImageLoad
-        img.onerror = (e) => reject(new Error(`Fail to load image: ${src}`))
+        img.onerror = () => reject(new Error(`Fail to load image: ${src}`))
       }
     })
   }
   clear (): void {
     this._context.clearRect(0, 0, this._width, this._height)
   }
-  update (imageData: ImageData): void {
+  update (imageData: NodeImageData): void {
     this._context.putImageData(<ImageData>imageData, 0, 0)
   }
   getWidth (): number {

--- a/src/image/node.ts
+++ b/src/image/node.ts
@@ -1,4 +1,4 @@
-import { Options, ImageData, ImageSource, ImageCallback } from '../typing'
+import { ImageData, ImageSource } from '../typing'
 import { ImageBase } from './base'
 import * as http from 'http'
 import * as https from 'https'

--- a/src/quantizer/mmcq.ts
+++ b/src/quantizer/mmcq.ts
@@ -1,6 +1,4 @@
 import {
-  Quantizer,
-  Filter,
   Pixels,
   ComputedOptions
 } from '../typing'

--- a/src/quantizer/worker/pool.ts
+++ b/src/quantizer/worker/pool.ts
@@ -1,9 +1,5 @@
 import { Swatch } from '../../color'
-import omit = require('lodash/omit')
-import find = require('lodash/find')
 import {
-  Quantizer,
-  Filter,
   Pixels,
   ComputedOptions
 } from '../../typing'
@@ -56,7 +52,7 @@ export default class WorkerPool {
       this._workers.push(worker)
       worker.onmessage = this._onMessage.bind(this, worker.id)
     } else {
-      worker = find(this._workers, 'idle')
+      worker = this._workers.find(worker => worker.idle)
     }
 
     return worker
@@ -97,15 +93,9 @@ export default class WorkerPool {
     this._executing[task.id] = task
 
     // Send payload
-    let request = <WorkerRequest>omit(task, 'deferred')
-    request.payload.opts = <ComputedOptions>omit(
-      request.payload.opts,
-      'ImageClass',
-      'combinedFilter',
-      'filters',
-      'generator',
-      'quantizer'
-    )
+    let { deferred, ...request } = task
+    let { ImageClass, combinedFilter, filters, generator, quantizer, ...payloadOpts } = request.payload.opts
+    request.payload.opts = payloadOpts as ComputedOptions
     worker.postMessage(request)
     worker.idle = false
   }

--- a/src/quantizer/worker/worker.ts
+++ b/src/quantizer/worker/worker.ts
@@ -6,6 +6,8 @@ import {
   WorkerErrorResponse
 } from './common'
 
+export declare var self: DedicatedWorkerGlobalScope
+
 self.onmessage = (event) => {
   let data: WorkerRequest = event.data
 
@@ -20,14 +22,12 @@ self.onmessage = (event) => {
       type: 'return',
       payload: swatches
     }
-  }
-  catch (e) {
+  } catch (e) {
     response = {
       id,
       type: 'error',
       payload: (<Error>e).message
     }
   }
-  (<any>self).postMessage(response)
+  self.postMessage(response)
 }
-

--- a/src/test/builder.spec.ts
+++ b/src/test/builder.spec.ts
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 import { expect } from 'chai'
 
-import Vibrant = require('../index')
-
-import omit = require('lodash/omit')
+import Vibrant = require('../')
 
 describe('builder', () => {
   it('modifies Vibrant options', () => {
@@ -26,8 +24,10 @@ describe('builder', () => {
       filters: [NOT_A_FILTER]
     }
 
-    expect(v.opts.combinedFilter, 'should have combined filter').to.be.a('function')
+    const { combinedFilter, ...opts } = v.opts
 
-    expect(omit(v.opts, 'combinedFilter')).to.deep.equal(expected)
+    expect(combinedFilter, 'should have combined filter').to.be.a('function')
+
+    expect(opts).to.deep.equal(expected)
   })
 })

--- a/src/test/common/data.ts
+++ b/src/test/common/data.ts
@@ -1,9 +1,7 @@
-import _ = require('lodash')
+import { Sample } from '../../../fixtures/sample/types'
 import path = require('path')
 
 export const TEST_PORT = 3444
-
-import { Sample } from '../../../fixtures/sample/types'
 export const SNAPSHOT: Sample[] = require('../../../fixtures/sample/images/palettes.json')
 
 export interface TestSample extends Sample {
@@ -13,7 +11,7 @@ export interface TestSample extends Sample {
 
 export type SamplePathKey = Exclude<keyof TestSample, 'palettes'>
 
-export const SAMPLES: TestSample[] = _.map(SNAPSHOT, (s) => _.assign(s, {
+export const SAMPLES: TestSample[] = SNAPSHOT.map((s) => Object.assign(s, {
   filePath: path.join(__dirname, '../../../fixtures/sample/images/', s.name),
   url: `http://localhost:${TEST_PORT}/${s.name}`,
   relativeUrl: `base/fixtures/sample/images/${s.name}`

--- a/src/test/common/helper.ts
+++ b/src/test/common/helper.ts
@@ -2,21 +2,17 @@
 import { expect } from 'chai'
 import { VibrantStatic } from '../../typing'
 import Builder from '../../builder'
-import path = require('path')
 import { Palette, Swatch } from '../../color'
-import util = require('../../util')
-import _ = require('lodash')
 import {
   TestSample, SamplePathKey
 } from './data'
 
 import { table, getBorderCharacters } from 'table'
-
+import util = require('../../util')
 
 const TABLE_OPTS = {
   border: getBorderCharacters('void')
 }
-
 
 const displayColorDiffTable = (diff: string[][]) => {
   console.log(table(diff, TABLE_OPTS))
@@ -66,14 +62,13 @@ const assertPalette = (reference: Palette, palette: Palette) => {
     displayColorDiffTable([nameRow, actualRow, expectedRow, scoreRow])
   }
 
-  expect(failCount, `${failCount} colors are too diffrent from reference palettes`)
+  expect(failCount, `${failCount} colors are too different from reference palettes`)
     .to.equal(0)
 }
 
 const paletteCallback = (references: any, sample: TestSample, done: MochaDone) =>
   (err: Error, palette?: Palette) => {
     setTimeout(() => {
-
       expect(err, `should not throw error '${err}'`).to.be.null
       assertPalette(references, palette)
 
@@ -91,7 +86,6 @@ export const testVibrant = (Vibrant: VibrantStatic, sample: TestSample, pathKey:
     builder.getPalette(paletteCallback(sample.palettes[env], sample, done))
   }
 }
-
 
 export const testVibrantAsPromised = (Vibrant: VibrantStatic, sample: TestSample, pathKey: SamplePathKey, env: 'node' | 'browser', builderCallback: (b: Builder) => Builder = null) => {
   return () => {

--- a/src/test/vibrant.spec.ts
+++ b/src/test/vibrant.spec.ts
@@ -11,7 +11,6 @@ import {
 import {
   createSampleServer
 } from './common/server'
-import Builder from '../builder'
 
 import http = require('http')
 

--- a/src/vibrant.ts
+++ b/src/vibrant.ts
@@ -3,8 +3,7 @@ import {
   ImageSource,
   Options,
   ComputedOptions,
-  Callback,
-  Filter
+  Callback
 } from './typing'
 
 import { Palette, Swatch } from './color'
@@ -16,8 +15,6 @@ import * as Util from './util'
 import * as Quantizer from './quantizer'
 import * as Generator from './generator'
 import * as Filters from './filter'
-
-import defaults = require('lodash/defaults')
 
 class Vibrant {
   static Builder = Builder
@@ -41,8 +38,8 @@ class Vibrant {
 
   opts: ComputedOptions
   private _palette: Palette
-  constructor(private _src: ImageSource, opts?: Partial<Options>) {
-    this.opts = <ComputedOptions>defaults({}, opts, Vibrant.DefaultOpts)
+  constructor (private _src: ImageSource, opts?: Partial<Options>) {
+    this.opts = Object.assign({}, Vibrant.DefaultOpts, opts) as ComputedOptions
     this.opts.combinedFilter = Filters.combineFilters(this.opts.filters)
   }
   private _process(image: Image, opts: ComputedOptions): Promise<Palette> {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,10 +4,13 @@
         "target": "es5",
         "noImplicitAny": true,
         "sourceMap": true,
+        "skipLibCheck": true,
         "lib": [
             "dom",
             "es5",
-            "es2015.promise"
+            "es2015.core",
+            "es2015.promise",
+            "webworker"
         ]
     },
     "include": [


### PR DESCRIPTION
Replaces use of lodash with built-in modules, slimming down the browser build.

Additionally replaced the old node `'url'` module with the global `URL` object that works in browsers, and cleaned up some unused imports.