### PR TITLE
Bugfix canvas tainted race condition

### DIFF
--- a/src/image/browser.ts
+++ b/src/image/browser.ts
@@ -46,11 +46,10 @@ export default class BrowserImage extends ImageBase {
     let src: string = null
     if (typeof image === 'string') {
       img = document.createElement('img')
-      src = img.src = image
-
-      if (!isRelativeUrl(src) && !isSameOrigin(window.location.href, src)) {
+      if (!isRelativeUrl(image) && !isSameOrigin(window.location.href, image)) {
         img.crossOrigin = 'anonymous'
       }
+      src = img.src = image
     } else if (image instanceof HTMLImageElement) {
       img = image
       src = image.src


### PR DESCRIPTION
Fixed #92. Avoids race condition by adding anonymous before setting the img.src. This way the crossOrigin will always be set when the image is being loaded.