### PR TITLE
Attach error handler to http[s].get()

### DIFF
--- a/src/image/node.ts
+++ b/src/image/node.ts
@@ -29,7 +29,7 @@ export default class NodeImage extends ImageBase {
         r.on('data', (data: any) => { buf = Buffer.concat([buf, data]) })
         r.on('end', () => resolve(buf))
         r.on('error', (e: Error) => reject(e))
-      })
+      }).on('error', (e: Error) => reject(e))
     })
   }
   private _loadFromPath (src: string): Promise<ImageBase> {


### PR DESCRIPTION
Resolves #98 - adding the error handler enables us to catch SSL related errors if the remote host has an invalid certificate.