### PR TITLE
Fixing the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ addons:
   firefox: "latest"
 before_script:
   - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3 # give xvfb some time to start
 jobs:
   include:
     - stage: build
       script: npm run build
     - stage: test
       script: npm run test
+services:
+  - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
 addons:
   firefox: "latest"
   chrome: "latest"
-before_script:
-  - export CHROME_BIN=chromium-browser
 jobs:
   include:
     - stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "11"
 addons:
   firefox: "latest"
+  chrome: "latest"
 before_script:
   - export CHROME_BIN=chromium-browser
 jobs:


### PR DESCRIPTION
It looks like TravisCi changes some things to make them better, but in doing so broke this build. There's an explanation here: https://benlimmer.com/2019/01/14/travis-ci-xvfb/

With the test suite running again, we're seeing a new error:
```
...
[karma-server]: Server start failed on port 9876: Error: not found: chromium-browser
```
...so I've also included Chrome to the list of addons alongside Firefox and removed the `CHROME_BIN` env var.