### PR TITLE
added Swatch to top-level Vibrant class

### DIFF
--- a/src/vibrant.ts
+++ b/src/vibrant.ts
@@ -25,6 +25,7 @@ class Vibrant {
   static Generator = Generator
   static Filter = Filters
   static Util = Util
+  static Swatch = Swatch
 
   static DefaultOpts: Partial<Options> = {
     colorCount: 64,


### PR DESCRIPTION
The current document shows that you can access Swatch as Vibrant.Swatch. This pull request fulfills that.